### PR TITLE
ci : PR목록 slack알림 구현

### DIFF
--- a/.github/scripts/pr_reminder.py
+++ b/.github/scripts/pr_reminder.py
@@ -1,0 +1,27 @@
+import os
+import requests
+from datetime import datetime
+
+GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
+SLACK_WEBHOOK_URL = os.environ['SLACK_WEBHOOK_URL']
+REPO = os.environ['GITHUB_REPOSITORY']
+
+def get_open_prs():
+    url = f"https://api.github.com/repos/{REPO}/pulls"
+    headers = {'Authorization': f'token {GITHUB_TOKEN}'}
+    response = requests.get(url, headers=headers)
+    return response.json()
+
+def send_slack_message(message):
+    payload = {'text': message}
+    requests.post(SLACK_WEBHOOK_URL, json=payload)
+
+prs = get_open_prs()
+if prs:
+    message = "리뷰가 필요한 PR 목록:\n"
+    for pr in prs:
+        message += f"• {pr['title']} - {pr['html_url']}\n"
+else:
+    message = "현재 리뷰가 필요한 PR이 없습니다."
+
+send_slack_message(message)

--- a/.github/workflows/pr-review-reminder.yml
+++ b/.github/workflows/pr-review-reminder.yml
@@ -1,0 +1,24 @@
+name: PR Review Reminder
+on:
+  schedule:
+    - cron: '0 1 * * *'  # UTC 기준 매일 01:00 (한국 시간 10:00)
+
+jobs:
+  send-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+      - name: Send PR reminder
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          python .github/scripts/pr_reminder.py


### PR DESCRIPTION
## 📝 PR 설명
<!-- 이 PR의 목적과 전반적인 변경 사항을 간단히 설명해주세요 -->
GitHub에서 진행 중인 Pull Request(PR)에 대한 리뷰 목록을 Slack을 통해 매일 알림받기 위해 Slack메시지를 자동으로 보내는 기능을 추가했습니다.

## 🛠 주요 변경 사항
<!-- 구체적인 변경 내용을 bullet point로 나열해주세요 -->
- 매일 오전 10시에 PR목록을 Slack을 통해 보낼 수 있도록 파일 추가

## 🧪 테스트 체크리스트
<!-- 테스트 방법 및 결과를 설명해주세요 -->
- [ ] 매일 오전 10시에 PR목록이 Slack을 통해 알림이 오는지 확인

## 🔗 관련 Jira 이슈
NTSWDP-89

## ➕ 추가 사항
<!-- PR관련 추가적으로 공지할 내용이나 코드 리뷰 요구사항을 적어주세요 ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
확인 결과 cron은 default브랜치에서만 작동이 됩니다. merge이후 테스트가 가능할 것 같습니다!

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
