### PR TITLE
[#101] 빌드 에러 해결을 위한 jdk 버전 고정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,12 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:5.6.0'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17) // JDK 17로 고정
+    }
+}
+
 jacoco {
     toolVersion = '0.8.7'    // Jacoco 버전 설정
 }


### PR DESCRIPTION
## 📝 PR 설명
해당 PR은 jacoco 버전과 호환되지 않는 jdk 버전일 경우 에러가 발생하여, jdk 버전을 17로 고정합니다.

## 🛠 주요 변경 사항
- build.gradle 수정

## 🧪 테스트 체크리스트
- [ ] 터미널에 ./gradlew build --stacktrace 입력
- [ ] 아래와 같은 jacoco 관련 에러가 뜨지 않는지 확인

`> Task :jacocoTestReport FAILED
> Task :jacocoTestCoverageVerification FAILED
Unsupported class file major version 66`

## 📸 스크린샷 또는 비디오


## 🔗 관련 Jira 이슈
101

## ➕ 추가 사항

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
