### PR TITLE
[#104] pause - restart 시 레벨 유지

### DIFF
--- a/src/main/java/engine/Core.java
+++ b/src/main/java/engine/Core.java
@@ -179,7 +179,11 @@ public final class Core {
 						returnCode = frame.setScreen(currentScreen);
 						LOGGER.info("Closing game screen.");
 
-						if (returnCode == 1 || returnCode == 2) break;
+						if (returnCode == 1) {
+							level = 1;
+							break;
+						}
+						if (returnCode == 2) break;
 						
 						achievementManager.updateAchievements(currentScreen); // TEAM CLOVER : Achievement
 						

--- a/src/test/java/screen/PauseTest.java
+++ b/src/test/java/screen/PauseTest.java
@@ -36,6 +36,7 @@ public class PauseTest {
         when(inputManager.isKeyDown(KeyEvent.VK_P)).thenReturn(true);
         when(inputManager.isKeyDown(KeyEvent.VK_R)).thenReturn(true);
         when(inputManager.isKeyDown(KeyEvent.VK_M)).thenReturn(true);
+        when(inputManager.isKeyDown(KeyEvent.VK_Q)).thenReturn(true);
     }
 
     @Test
@@ -76,7 +77,7 @@ public class PauseTest {
         // 게임이 다시 실행되는지 확인
         assertFalse(gameScreen.getIsPaused());
 
-        // Mock 객체의 특정 메서드가 호출됐는지 검증
+        // GameScreen Spy 객체의 resumeGame() 메서드가 호출됐는지 검증
         verify(gameScreen, times(1)).resumeGame();
     }
 
@@ -102,42 +103,32 @@ public class PauseTest {
         assertFalse(gameScreen.getIsRunning());
         assertFalse(gameScreen.getIsPaused());
 
-        // Mock 객체의 특정 메서드가 호출됐는지 검증
+        // GameScreen Spy 객체의 exitGame() 메서드가 호출됐는지 검증
         verify(gameScreen, times(1)).exitGame();
     }
 
-//    @Test
-//    public void testGameStopsDuringPause() {
-//        // 초기 상태: 게임은 일시정지 상태가 아님
-//        assertFalse(gameScreen.getIsPaused());
-//
-//        int preTime = gameState.getTime();
-//        int preLevel = gameState.getLevel();
-//        int preLives = gameState.getLivesRemaining();
-//
-//        // Pause 시도
-//        if (inputManager.isKeyDown(KeyEvent.VK_P)) {
-//            gameScreen.pauseGame();
-//        }
-//
-//        // 일시정지 상태 확인
-//        assertTrue(gameScreen.getIsPaused());
-//
-//        // Resume 시도
-//        doAnswer(invocation -> {
-//            when(gameScreen.getIsPaused()).thenReturn(false);
-//            return null;
-//        }).when(gameScreen).resumeGame();
-//
-//        // Resume 메서드 호출
-//        gameScreen.resumeGame();
-//
-//        // 게임이 다시 실행되는지 확인
-//        assertFalse(gameScreen.getIsPaused());
-//
-//        // 게임이 일시정지된 동안 GameState가 바뀌지 않았는지 확인
-//        assertEquals(preTime, gameState.getTime());
-//        assertEquals(preLevel, gameState.getLevel());
-//        assertEquals(preLives, gameState.getLivesRemaining());
-//    }
+    @Test
+    public void testRestartKeyRestartsGame() {
+        // 초기 상태: 게임은 일시정지 상태가 아님
+        assertFalse(gameScreen.getIsPaused());
+
+        // Pause 시도
+        if (inputManager.isKeyDown(KeyEvent.VK_P)) {
+            gameScreen.pauseGame();
+        }
+
+        // 일시정지 상태 확인
+        assertTrue(gameScreen.getIsPaused());
+
+        // Resume 시도
+        if (gameScreen.getIsPaused() && inputManager.isKeyDown(KeyEvent.VK_Q)) {
+            gameScreen.restartGame();
+        }
+
+        // 게임이 재시작됐는지 확인
+        assertFalse(gameScreen.getIsPaused());
+
+        // GameScreen Spy 객체의 restartGame() 메서드가 호출됐는지 검증
+        verify(gameScreen, times(1)).restartGame();
+    }
 }


### PR DESCRIPTION
## 📝 PR 설명
해당 PR은 pause menu 중 restart 선택 시 레벨이 초기화되는 문제를 해결합니다.

## 🛠 주요 변경 사항
- restart 관련 테스트 코드 추가
- 관련 로직 구현

## 🧪 테스트 체크리스트
<!-- 테스트 방법 및 결과를 설명해주세요 -->
- [ ] 게임 실행
- [ ] 'ESC' or 'P' 키로 게임 일시정지
- [ ] 'Q' 키를 눌러 재시작
- [ ] 레벨이 유지되는지 확인

## 📸 스크린샷 또는 비디오


## 🔗 관련 Jira 이슈
NTSWDP-104

## ➕ 추가 사항
이후 pr할 내용이 해당 pr이 적용이 선행되어야 해서, 최대한 빠른 리뷰 부탁드립니다!

## ✅ 체크리스트
- [ ] 코드 컨벤션을 준수했습니다
- [ ] 불필요한 코드를 제거했습니다
- [ ] 주석 처리를 필요한 만큼 하였습니다.
- [ ] PR 제목 또는 설명에 Jira 이슈 키를 포함했습니다

## 📑 P-n룰 설명
### comment남기실 때 P-n규칙 꼭 남겨주세요!
- P1: 꼭 반영해주세요 (Request changes)
- P2: 적극적으로 고려해주세요 (Request changes)
- P3: 웬만하면 반영해 주세요 (Comment)
- P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
- P5: 그냥 사소한 의견입니다 (Approve)
